### PR TITLE
Fix typo of interpret-as

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ssmlDoc.say('I am talking to you.');
 
 The text string can also be described by the `text` parameter.
 
-`intepretAs` can also be specified as an additional parameter, but will encapsulate the text-output into a `say-as` element. More parameters can be specified for the `say-as` element, only *if* `intepretAs` is used:
+`interpretAs` can also be specified as an additional parameter, but will encapsulate the text-output into a `say-as` element. More parameters can be specified for the `say-as` element, only *if* `interpretAs` is used:
 
 * `format`
 * `detail`
@@ -93,7 +93,7 @@ Example:
 ssmlDoc.say('The time now is ')
     .say({
         text: '01:59:59',
-        intepretAs: 'telephone',
+        interpretAs: 'telephone',
         format: 'hms24'
     })
     .toString();

--- a/index.js
+++ b/index.js
@@ -47,13 +47,13 @@ function Say(options) {
     if (!(this instanceof Say))
         return new Say(options);
     if (options) {
-        _.extend(this, _.pick(options, 'text', 'intepretAs', 'format', 'detail'));
+        _.extend(this, _.pick(options, 'text', 'interpretAs', 'format', 'detail'));
     }
 }
 
 Say.prototype.isValid = function isSayValid() {
     if (!_.isString(this.text)) return false;
-    if (isInvalid(this.intepretAs)) return false;
+    if (isInvalid(this.interpretAs)) return false;
     return true;
 }
 
@@ -66,10 +66,10 @@ Say.prototype.renderInto = function renderSayInto(xml, replacer) {
         subElement.att('alias', replacer[replacedText]).txt(replacedText);
         outputText = outputText.replace(new RegExp(replacedText, 'g'), subElement.end());
     }
-    if (this.intepretAs) {
+    if (this.interpretAs) {
         var sayAsElement = xml.ele('say-as');
         sayAsElement.raw(outputText);
-        sayAsElement.att('intepret-as', this.intepretAs);
+        sayAsElement.att('interpret-as', this.interpretAs);
         if (_.isString(this.format))
             sayAsElement.att('format', this.format);
         if (_.isString(this.detail))


### PR DESCRIPTION
Found that `interpret-as` was misspelled as `intepret-as` in the generated SSML. This also happened with variable names, which were misspelled as `intepretAs`. Fixes the misspellings to reduce confusion and create valid SSML. 