### PR TITLE
Make EndElement.renderElement actually navigate to the parent node

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ EndElement.prototype.isValid = function isEndElementValid() {
 }
 
 EndElement.prototype.renderInto = function renderEndElementInto(xml) {
-    if (xml.isRoot) return xml.up();
+    if (!xml.isRoot) return xml.up();
     return xml;
 }
 


### PR DESCRIPTION
I think the current code has a typo